### PR TITLE
Consolidate scan reconciliation into a single Gemini call and add spec update option

### DIFF
--- a/src/specdrift/cli.py
+++ b/src/specdrift/cli.py
@@ -1167,6 +1167,7 @@ def scan(
                     anomaly_summary=combined_summary,
                     endpoint_context=endpoint_context,
                     model=selected_model,
+                    consolidated=True,
                 )
             )
             for _, report in drift_reports:

--- a/src/specdrift/cli.py
+++ b/src/specdrift/cli.py
@@ -22,7 +22,15 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskPr
 from rich.table import Table
 from rich.text import Text
 
-from specdrift.types import ApiKeyLocation, AuthType, DecisionType, DriftReport, HttpMethod
+from specdrift.types import (
+    ApiKeyLocation,
+    AuthType,
+    DecisionType,
+    DriftReport,
+    HttpMethod,
+    Anomaly,
+    AnomalySummary,
+)
 
 console = Console()
 app = typer.Typer(
@@ -225,6 +233,50 @@ def _resolve_path(value: Path | str, base_dir: Path) -> Path:
     if path_value.is_absolute():
         return path_value
     return base_dir / path_value
+
+
+def _build_combined_reconciliation_payload(
+    reports: list[tuple[str, DriftReport]],
+) -> tuple[dict[str, Any], AnomalySummary, str]:
+    """Build a single reconciliation payload for all drifting endpoints."""
+    combined_fragment: dict[str, Any] = {"paths": {}}
+    combined_anomalies: list[Anomaly] = []
+    endpoint_labels: list[str] = []
+    response_sample: dict[str, Any] = {}
+
+    for label, report in reports:
+        endpoint_labels.append(label)
+        if report.updated_spec_fragment and report.updated_spec_fragment.get("paths"):
+            combined_fragment["paths"].update(report.updated_spec_fragment["paths"])
+
+        if report.anomaly_summary:
+            for anomaly in report.anomaly_summary.anomalies:
+                combined_anomalies.append(
+                    Anomaly(
+                        anomaly_type=anomaly.anomaly_type,
+                        json_path=f"{label}:{anomaly.json_path}",
+                        expected=anomaly.expected,
+                        actual=anomaly.actual,
+                        message=anomaly.message,
+                    )
+                )
+            response_sample[label] = report.anomaly_summary.response_sample
+
+    anomalies_by_type: dict[Any, int] = {}
+    for anomaly in combined_anomalies:
+        anomalies_by_type[anomaly.anomaly_type] = anomalies_by_type.get(anomaly.anomaly_type, 0) + 1
+
+    combined_summary = AnomalySummary(
+        total_anomalies=len(combined_anomalies),
+        anomalies_by_type=anomalies_by_type,
+        anomalies=combined_anomalies,
+        response_sample=response_sample,
+    )
+
+    endpoint_context = "Multi-endpoint scan with drift:\n" + "\n".join(
+        f"- {endpoint_label}" for endpoint_label in endpoint_labels
+    )
+    return combined_fragment, combined_summary, endpoint_context
 
 
 @app.command()
@@ -813,13 +865,20 @@ def scan(
     token_scope: str | None = typer.Option(None, "--token-scope"),
     token_audience: str | None = typer.Option(None, "--token-audience"),
     output_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+    update_spec: bool = typer.Option(
+        False,
+        "--update-spec",
+        help="Apply consolidated UPDATE_SPEC recommendation to the spec file",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:
     """Interactively scan an OpenAPI spec — pick model, select endpoints, analyze."""
     from InquirerPy import inquirer
     from InquirerPy.separator import Separator
-    from specdrift.modules.openapi_parser import load_spec_from_file
+    from specdrift.modules.openapi_parser import load_spec_from_file, find_matching_endpoint
     from specdrift.modules.pipeline import analyze_endpoint
+    from specdrift.modules.semantic_reconciler import reconcile_with_llm
+    from specdrift.modules.spec_updater import apply_updates, save_spec
 
     setup_logging(verbose=verbose)
 
@@ -1052,6 +1111,20 @@ def scan(
             ep_body = ep_cfg.get("body")
 
             try:
+                parsed_endpoint = find_matching_endpoint(parsed_spec, ep_path, HttpMethod(ep_method))
+                endpoint_fragment = None
+                if parsed_endpoint:
+                    path_item = parsed_spec.raw_spec.get("paths", {}).get(parsed_endpoint.path, {})
+                    method_lower = ep_method.lower()
+                    if method_lower in path_item:
+                        endpoint_fragment = {
+                            "paths": {
+                                parsed_endpoint.path: {
+                                    method_lower: path_item[method_lower],
+                                }
+                            }
+                        }
+
                 ep_report = asyncio.run(
                     analyze_endpoint(
                         spec_path=str(spec_path),
@@ -1063,9 +1136,11 @@ def scan(
                         query_params=ep_query or None,
                         body=ep_body,
                         model=selected_model,
+                        invoke_llm=False,
                         **resolved_auth,
                     )
                 )
+                ep_report.updated_spec_fragment = endpoint_fragment
                 reports.append((label, ep_report, None))
             except Exception as e:
                 reports.append((label, None, str(e)))
@@ -1074,6 +1149,51 @@ def scan(
 
     console.print()
 
+    drift_reports = [
+        (label, report)
+        for label, report, error in reports
+        if error is None and report is not None and report.has_drift
+    ]
+
+    if drift_reports:
+        console.print("[bold]Step 5:[/bold] Running consolidated LLM reconciliation\n")
+        combined_fragment, combined_summary, endpoint_context = _build_combined_reconciliation_payload(
+            drift_reports
+        )
+        try:
+            consolidated_decision = asyncio.run(
+                reconcile_with_llm(
+                    openapi_fragment=combined_fragment,
+                    anomaly_summary=combined_summary,
+                    endpoint_context=endpoint_context,
+                    model=selected_model,
+                )
+            )
+            for _, report in drift_reports:
+                report.llm_decision = consolidated_decision
+                report.auto_update_recommended = (
+                    consolidated_decision.decision == DecisionType.UPDATE_SPEC
+                    and consolidated_decision.confidence >= 0.85
+                )
+
+            if update_spec and consolidated_decision.decision == DecisionType.UPDATE_SPEC:
+                fragment = consolidated_decision.updated_openapi_fragment
+                if fragment:
+                    updated_spec = apply_updates(parsed_spec.raw_spec, fragment)
+                    save_spec(updated_spec, str(spec_path))
+                    console.print(
+                        f"[green]Updated spec saved to[/green] [bold]{spec_path}[/bold]"
+                    )
+                else:
+                    console.print(
+                        "[yellow]LLM returned UPDATE_SPEC without fragment; spec not modified.[/yellow]"
+                    )
+        except Exception as exc:
+            error_message = f"Consolidated reconciliation failed: {exc}"
+            reports = [
+                (lbl, rpt, error_message if (rpt is not None and rpt.has_drift and err is None) else err)
+                for lbl, rpt, err in reports
+            ]
     # ── Step 5: Display results ───────────────────────────────────────────
     console.print("[bold]Step 5:[/bold] Results\n")
 

--- a/src/specdrift/modules/pipeline.py
+++ b/src/specdrift/modules/pipeline.py
@@ -53,6 +53,7 @@ async def analyze_endpoint(
     token_scope: str | None = None,
     token_audience: str | None = None,
     model: str | None = None,
+    invoke_llm: bool = True,
 ) -> DriftReport:
     """Analyze a single endpoint for spec drift.
 
@@ -148,6 +149,7 @@ async def analyze_endpoint(
         method=method,
         expected_status=expected_status,
         model=model,
+        invoke_llm=invoke_llm,
     )
 
 
@@ -160,6 +162,7 @@ async def analyze_response(
     method: HttpMethod,
     expected_status: int,
     model: str | None = None,
+    invoke_llm: bool = True,
 ) -> DriftReport:
     """Analyze a recorded response against a schema.
 
@@ -214,6 +217,16 @@ async def analyze_response(
     logger.info("Step 6: Summarizing anomalies for LLM...")
     anomaly_summary = summarize_anomalies(anomalies, response.body)
     logger.info(f"   Anomaly types: {list(anomaly_summary.anomalies_by_type.keys())}")
+
+    if not invoke_llm:
+        logger.info("   LLM invocation deferred by caller")
+        return DriftReport(
+            endpoint=endpoint_context,
+            spec_path=spec_path,
+            anomaly_summary=anomaly_summary,
+            has_drift=True,
+            auto_update_recommended=False,
+        )
 
     # Step 7: Get the OpenAPI fragment for this endpoint
     logger.info("Step 7: Extracting OpenAPI fragment...")

--- a/src/specdrift/modules/semantic_reconciler/llm_client.py
+++ b/src/specdrift/modules/semantic_reconciler/llm_client.py
@@ -13,7 +13,11 @@ from google.genai import types
 
 from specdrift.types import AnomalySummary, LLMDecision, DecisionType, ChangeType, ChangeInstruction
 
-from .prompt_builder import build_reconciliation_prompt, get_system_prompt
+from .prompt_builder import (
+    build_consolidated_reconciliation_prompt,
+    build_reconciliation_prompt,
+    get_system_prompt,
+)
 
 
 # Set up logging
@@ -69,6 +73,7 @@ async def reconcile_with_llm(
     endpoint_context: str,
     model: str = DEFAULT_MODEL,
     api_key: str | None = None,
+    consolidated: bool = False,
 ) -> LLMDecision:
     """Use the LLM to reconcile spec drift.
     
@@ -80,6 +85,7 @@ async def reconcile_with_llm(
         endpoint_context: Context about the endpoint (path, method).
         model: Gemini model to use.
         api_key: Optional API key (uses GOOGLE_API_KEY env var if not provided).
+        consolidated: Whether this is a multi-endpoint consolidated reconciliation call.
         
     Returns:
         LLMDecision with classification and proposed changes.
@@ -98,11 +104,18 @@ async def reconcile_with_llm(
     logger.debug(f"   Anomalies: {anomaly_summary.total_anomalies}")
     
     # Build the prompt
-    user_prompt = build_reconciliation_prompt(
-        openapi_fragment=openapi_fragment,
-        anomaly_summary=anomaly_summary,
-        endpoint_context=endpoint_context,
-    )
+    if consolidated:
+        user_prompt = build_consolidated_reconciliation_prompt(
+            openapi_fragment=openapi_fragment,
+            anomaly_summary=anomaly_summary,
+            endpoint_context=endpoint_context,
+        )
+    else:
+        user_prompt = build_reconciliation_prompt(
+            openapi_fragment=openapi_fragment,
+            anomaly_summary=anomaly_summary,
+            endpoint_context=endpoint_context,
+        )
     
     logger.debug(f"   Prompt length: {len(user_prompt)} chars")
     

--- a/src/specdrift/modules/semantic_reconciler/prompt_builder.py
+++ b/src/specdrift/modules/semantic_reconciler/prompt_builder.py
@@ -30,20 +30,10 @@ def build_reconciliation_prompt(
     anomaly_summary: AnomalySummary,
     endpoint_context: str,
 ) -> str:
-    """Build a prompt for the LLM to analyze spec drift.
-    
-    Args:
-        openapi_fragment: Relevant portion of the OpenAPI spec.
-        anomaly_summary: Summary of detected anomalies.
-        endpoint_context: Context about the endpoint (path, method).
-        
-    Returns:
-        Formatted prompt string.
-    """
-    # Format anomalies for readability
+    """Build a prompt for single-endpoint LLM reconciliation."""
     anomalies_text = format_anomalies(anomaly_summary)
-    
-    prompt = f"""## Endpoint Context
+
+    return f"""## Endpoint Context
 {endpoint_context}
 
 ## Current OpenAPI Specification Fragment
@@ -60,15 +50,47 @@ def build_reconciliation_prompt(
 {anomalies_text}
 
 ## Task
-Analyze the anomalies above and decide:
+Analyze this single endpoint and decide:
 1. Should the OpenAPI spec be updated? (UPDATE_SPEC)
 2. Is this an API bug? (API_BUG)
 3. Does this need human review? (NEEDS_REVIEW)
 
-For UPDATE_SPEC decisions, provide the minimal updated OpenAPI fragment.
+For UPDATE_SPEC decisions, provide the minimal updated OpenAPI fragment for this endpoint only.
 Consider backward compatibility and real-world API evolution patterns."""
 
-    return prompt
+
+def build_consolidated_reconciliation_prompt(
+    openapi_fragment: dict[str, Any],
+    anomaly_summary: AnomalySummary,
+    endpoint_context: str,
+) -> str:
+    """Build a prompt for multi-endpoint consolidated LLM reconciliation."""
+    anomalies_text = format_anomalies(anomaly_summary)
+
+    return f"""## Endpoint Group Context
+{endpoint_context}
+
+## Current OpenAPI Specification Fragment (multiple endpoints)
+```json
+{json.dumps(openapi_fragment, indent=2)}
+```
+
+## Observed Response Samples (keyed by endpoint)
+```json
+{json.dumps(anomaly_summary.response_sample, indent=2)}
+```
+
+## Detected Anomalies Across Endpoints ({anomaly_summary.total_anomalies} total)
+{anomalies_text}
+
+## Task
+Analyze all endpoint deviations together and decide:
+1. Should the OpenAPI spec be updated? (UPDATE_SPEC)
+2. Are these API bugs? (API_BUG)
+3. Does this need human review? (NEEDS_REVIEW)
+
+For UPDATE_SPEC decisions, provide a minimal updated OpenAPI fragment that may include multiple endpoints.
+Use cross-endpoint consistency as evidence, but avoid over-generalizing changes."""
 
 
 def format_anomalies(summary: AnomalySummary) -> str:

--- a/tests/unit/test_prompt_builder.py
+++ b/tests/unit/test_prompt_builder.py
@@ -1,0 +1,48 @@
+"""Unit tests for semantic reconciler prompt variants."""
+
+from specdrift.modules.semantic_reconciler.prompt_builder import (
+    build_consolidated_reconciliation_prompt,
+    build_reconciliation_prompt,
+)
+from specdrift.types import Anomaly, AnomalySummary, AnomalyType
+
+
+def _sample_summary() -> AnomalySummary:
+    return AnomalySummary(
+        total_anomalies=1,
+        anomalies_by_type={AnomalyType.ADDITIONAL_FIELD: 1},
+        anomalies=[
+            Anomaly(
+                anomaly_type=AnomalyType.ADDITIONAL_FIELD,
+                json_path="$.name",
+                expected="absent",
+                actual="Alice",
+                message="unexpected field",
+            )
+        ],
+        response_sample={"name": "Alice"},
+    )
+
+
+def test_single_endpoint_prompt_contains_single_endpoint_guidance() -> None:
+    prompt = build_reconciliation_prompt(
+        openapi_fragment={"paths": {"/users/{id}": {"get": {}}}},
+        anomaly_summary=_sample_summary(),
+        endpoint_context="GET /users/1",
+    )
+
+    assert "Analyze this single endpoint" in prompt
+    assert "for this endpoint only" in prompt
+    assert "Endpoint Context" in prompt
+
+
+def test_consolidated_prompt_contains_multi_endpoint_guidance() -> None:
+    prompt = build_consolidated_reconciliation_prompt(
+        openapi_fragment={"paths": {"/users/{id}": {"get": {}}, "/health": {"get": {}}}},
+        anomaly_summary=_sample_summary(),
+        endpoint_context="Multi-endpoint scan with drift:\n- GET /users/1\n- GET /health",
+    )
+
+    assert "Endpoint Group Context" in prompt
+    assert "Analyze all endpoint deviations together" in prompt
+    assert "may include multiple endpoints" in prompt

--- a/tests/unit/test_scan_config.py
+++ b/tests/unit/test_scan_config.py
@@ -7,10 +7,12 @@ from pathlib import Path
 import pytest
 
 from specdrift.cli import (
+    _build_combined_reconciliation_payload,
     _ensure_string_dict,
     _load_config,
     _resolve_env_placeholders,
 )
+from specdrift.types import Anomaly, AnomalySummary, AnomalyType, DriftReport
 
 
 class TestBaseUrlConfig:
@@ -229,3 +231,59 @@ class TestCliCommands:
         click_app = typer.main.get_command(app)
         commands = list(click_app.commands.keys())
         assert "version" in commands
+
+
+class TestConsolidatedReconciliationPayload:
+    """Tests for merged multi-endpoint reconciliation payload creation."""
+
+    def test_build_payload_merges_paths_and_anomalies(self) -> None:
+        report_a = DriftReport(
+            endpoint="GET /users/1",
+            spec_path="openapi.yaml",
+            has_drift=True,
+            updated_spec_fragment={"paths": {"/users/{id}": {"get": {"responses": {}}}}},
+            anomaly_summary=AnomalySummary(
+                total_anomalies=1,
+                anomalies_by_type={AnomalyType.ADDITIONAL_FIELD: 1},
+                anomalies=[
+                    Anomaly(
+                        anomaly_type=AnomalyType.ADDITIONAL_FIELD,
+                        json_path="$.nickname",
+                        expected="absent",
+                        actual="Sam",
+                        message="extra field",
+                    )
+                ],
+                response_sample={"id": 1, "nickname": "Sam"},
+            ),
+        )
+        report_b = DriftReport(
+            endpoint="GET /health",
+            spec_path="openapi.yaml",
+            has_drift=True,
+            updated_spec_fragment={"paths": {"/health": {"get": {"responses": {}}}}},
+            anomaly_summary=AnomalySummary(
+                total_anomalies=1,
+                anomalies_by_type={AnomalyType.TYPE_MISMATCH: 1},
+                anomalies=[
+                    Anomaly(
+                        anomaly_type=AnomalyType.TYPE_MISMATCH,
+                        json_path="$.status",
+                        expected="string",
+                        actual=200,
+                        message="wrong type",
+                    )
+                ],
+                response_sample={"status": 200},
+            ),
+        )
+
+        fragment, summary, context = _build_combined_reconciliation_payload(
+            [("GET /users/1", report_a), ("GET /health", report_b)]
+        )
+
+        assert "/users/{id}" in fragment["paths"]
+        assert "/health" in fragment["paths"]
+        assert summary.total_anomalies == 2
+        assert any(anom.json_path.startswith("GET /users/1:") for anom in summary.anomalies)
+        assert "GET /health" in context


### PR DESCRIPTION
### Motivation
- Reduce Gemini/API overhead during multi-endpoint `scan` runs by batching LLM invocations when multiple endpoints show drift.
- Allow applying LLM-recommended `UPDATE_SPEC` changes back into the OpenAPI file from the interactive `scan` flow.

### Description
- Added an `invoke_llm` switch to the pipeline (`analyze_endpoint` / `analyze_response`) so per-endpoint deterministic diffing can run without immediately calling the LLM and can return an anomaly summary for later reconciliation.
- Implemented `_build_combined_reconciliation_payload` to merge per-endpoint OpenAPI fragments and anomalies into a single reconciliation payload for one Gemini call.
- Updated `scan` to run deterministic checks per endpoint with `invoke_llm=False`, then perform one consolidated `reconcile_with_llm` call when any endpoint has drift, and attach the consolidated decision to each drifting endpoint.
- Added a `--update-spec` CLI option to `scan` which applies the consolidated `UPDATE_SPEC` `updated_openapi_fragment` to the source spec using the existing spec updater helpers when the model recommends it.
- Added unit tests for the consolidated payload builder and adjusted existing tests to cover the new behavior.

### Testing
- Ran targeted unit tests: `PYTHONPATH=src pytest -q tests/unit/test_scan_config.py tests/unit/test_pipeline_path_query.py` and they passed (`18 passed, 1 warning`).
- Verified syntax/bytecode by running `python -m py_compile src/specdrift/cli.py src/specdrift/modules/pipeline.py tests/unit/test_scan_config.py` which succeeded.
- Attempting a full `pytest -q` in this environment failed during collection due to missing integration dependencies and environment setup (e.g., `fastapi` and package import path), not due to the changes themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fbb9c5f4832e94b98a2bfe609f1f)